### PR TITLE
added warning for unsupported browsers

### DIFF
--- a/public/js/browserCompatibilityCheck.js
+++ b/public/js/browserCompatibilityCheck.js
@@ -1,0 +1,652 @@
+/* eslint-disable */
+(function () {
+  /*!
+   * Bowser - a browser detector
+   * https://github.com/ded/bowser
+   * MIT License | (c) Dustin Diaz 2015
+   */
+
+  var bowser = function() {
+    /**
+      * See useragents.js for examples of navigator.userAgent
+      */
+
+    var t = true
+
+    function detect(ua) {
+
+      function getFirstMatch(regex) {
+        var match = ua.match(regex);
+        return (match && match.length > 1 && match[1]) || '';
+      }
+
+      function getSecondMatch(regex) {
+        var match = ua.match(regex);
+        return (match && match.length > 1 && match[2]) || '';
+      }
+
+      var iosdevice = getFirstMatch(/(ipod|iphone|ipad)/i).toLowerCase()
+        , likeAndroid = /like android/i.test(ua)
+        , android = !likeAndroid && /android/i.test(ua)
+        , nexusMobile = /nexus\s*[0-6]\s*/i.test(ua)
+        , nexusTablet = !nexusMobile && /nexus\s*[0-9]+/i.test(ua)
+        , chromeos = /CrOS/.test(ua)
+        , silk = /silk/i.test(ua)
+        , sailfish = /sailfish/i.test(ua)
+        , tizen = /tizen/i.test(ua)
+        , webos = /(web|hpw)os/i.test(ua)
+        , windowsphone = /windows phone/i.test(ua)
+        , samsungBrowser = /SamsungBrowser/i.test(ua)
+        , windows = !windowsphone && /windows/i.test(ua)
+        , mac = !iosdevice && !silk && /macintosh/i.test(ua)
+        , linux = !android && !sailfish && !tizen && !webos && /linux/i.test(ua)
+        , edgeVersion = getSecondMatch(/edg([ea]|ios)\/(\d+(\.\d+)?)/i)
+        , versionIdentifier = getFirstMatch(/version\/(\d+(\.\d+)?)/i)
+        , tablet = /tablet/i.test(ua) && !/tablet pc/i.test(ua)
+        , mobile = !tablet && /[^-]mobi/i.test(ua)
+        , xbox = /xbox/i.test(ua)
+        , result
+
+      if (/opera/i.test(ua)) {
+        //  an old Opera
+        result = {
+          name: 'Opera'
+        , opera: t
+        , version: versionIdentifier || getFirstMatch(/(?:opera|opr|opios)[\s\/](\d+(\.\d+)?)/i)
+        }
+      } else if (/opr\/|opios/i.test(ua)) {
+        // a new Opera
+        result = {
+          name: 'Opera'
+          , opera: t
+          , version: getFirstMatch(/(?:opr|opios)[\s\/](\d+(\.\d+)?)/i) || versionIdentifier
+        }
+      }
+      else if (/SamsungBrowser/i.test(ua)) {
+        result = {
+          name: 'Samsung Internet for Android'
+          , samsungBrowser: t
+          , version: versionIdentifier || getFirstMatch(/(?:SamsungBrowser)[\s\/](\d+(\.\d+)?)/i)
+        }
+      }
+      else if (/coast/i.test(ua)) {
+        result = {
+          name: 'Opera Coast'
+          , coast: t
+          , version: versionIdentifier || getFirstMatch(/(?:coast)[\s\/](\d+(\.\d+)?)/i)
+        }
+      }
+      else if (/yabrowser/i.test(ua)) {
+        result = {
+          name: 'Yandex Browser'
+        , yandexbrowser: t
+        , version: versionIdentifier || getFirstMatch(/(?:yabrowser)[\s\/](\d+(\.\d+)?)/i)
+        }
+      }
+      else if (/ucbrowser/i.test(ua)) {
+        result = {
+            name: 'UC Browser'
+          , ucbrowser: t
+          , version: getFirstMatch(/(?:ucbrowser)[\s\/](\d+(?:\.\d+)+)/i)
+        }
+      }
+      else if (/mxios/i.test(ua)) {
+        result = {
+          name: 'Maxthon'
+          , maxthon: t
+          , version: getFirstMatch(/(?:mxios)[\s\/](\d+(?:\.\d+)+)/i)
+        }
+      }
+      else if (/epiphany/i.test(ua)) {
+        result = {
+          name: 'Epiphany'
+          , epiphany: t
+          , version: getFirstMatch(/(?:epiphany)[\s\/](\d+(?:\.\d+)+)/i)
+        }
+      }
+      else if (/puffin/i.test(ua)) {
+        result = {
+          name: 'Puffin'
+          , puffin: t
+          , version: getFirstMatch(/(?:puffin)[\s\/](\d+(?:\.\d+)?)/i)
+        }
+      }
+      else if (/sleipnir/i.test(ua)) {
+        result = {
+          name: 'Sleipnir'
+          , sleipnir: t
+          , version: getFirstMatch(/(?:sleipnir)[\s\/](\d+(?:\.\d+)+)/i)
+        }
+      }
+      else if (/k-meleon/i.test(ua)) {
+        result = {
+          name: 'K-Meleon'
+          , kMeleon: t
+          , version: getFirstMatch(/(?:k-meleon)[\s\/](\d+(?:\.\d+)+)/i)
+        }
+      }
+      else if (windowsphone) {
+        result = {
+          name: 'Windows Phone'
+        , osname: 'Windows Phone'
+        , windowsphone: t
+        }
+        if (edgeVersion) {
+          result.msedge = t
+          result.version = edgeVersion
+        }
+        else {
+          result.msie = t
+          result.version = getFirstMatch(/iemobile\/(\d+(\.\d+)?)/i)
+        }
+      }
+      else if (/msie|trident/i.test(ua)) {
+        result = {
+          name: 'Internet Explorer'
+        , msie: t
+        , version: getFirstMatch(/(?:msie |rv:)(\d+(\.\d+)?)/i)
+        }
+      } else if (chromeos) {
+        result = {
+          name: 'Chrome'
+        , osname: 'Chrome OS'
+        , chromeos: t
+        , chromeBook: t
+        , chrome: t
+        , version: getFirstMatch(/(?:chrome|crios|crmo)\/(\d+(\.\d+)?)/i)
+        }
+      } else if (/edg([ea]|ios)/i.test(ua)) {
+        result = {
+          name: 'Microsoft Edge'
+        , msedge: t
+        , version: edgeVersion
+        }
+      }
+      else if (/vivaldi/i.test(ua)) {
+        result = {
+          name: 'Vivaldi'
+          , vivaldi: t
+          , version: getFirstMatch(/vivaldi\/(\d+(\.\d+)?)/i) || versionIdentifier
+        }
+      }
+      else if (sailfish) {
+        result = {
+          name: 'Sailfish'
+        , osname: 'Sailfish OS'
+        , sailfish: t
+        , version: getFirstMatch(/sailfish\s?browser\/(\d+(\.\d+)?)/i)
+        }
+      }
+      else if (/seamonkey\//i.test(ua)) {
+        result = {
+          name: 'SeaMonkey'
+        , seamonkey: t
+        , version: getFirstMatch(/seamonkey\/(\d+(\.\d+)?)/i)
+        }
+      }
+      else if (/firefox|iceweasel|fxios/i.test(ua)) {
+        result = {
+          name: 'Firefox'
+        , firefox: t
+        , version: getFirstMatch(/(?:firefox|iceweasel|fxios)[ \/](\d+(\.\d+)?)/i)
+        }
+        if (/\((mobile|tablet);[^\)]*rv:[\d\.]+\)/i.test(ua)) {
+          result.firefoxos = t
+          result.osname = 'Firefox OS'
+        }
+      }
+      else if (silk) {
+        result =  {
+          name: 'Amazon Silk'
+        , silk: t
+        , version : getFirstMatch(/silk\/(\d+(\.\d+)?)/i)
+        }
+      }
+      else if (/phantom/i.test(ua)) {
+        result = {
+          name: 'PhantomJS'
+        , phantom: t
+        , version: getFirstMatch(/phantomjs\/(\d+(\.\d+)?)/i)
+        }
+      }
+      else if (/slimerjs/i.test(ua)) {
+        result = {
+          name: 'SlimerJS'
+          , slimer: t
+          , version: getFirstMatch(/slimerjs\/(\d+(\.\d+)?)/i)
+        }
+      }
+      else if (/blackberry|\bbb\d+/i.test(ua) || /rim\stablet/i.test(ua)) {
+        result = {
+          name: 'BlackBerry'
+        , osname: 'BlackBerry OS'
+        , blackberry: t
+        , version: versionIdentifier || getFirstMatch(/blackberry[\d]+\/(\d+(\.\d+)?)/i)
+        }
+      }
+      else if (webos) {
+        result = {
+          name: 'WebOS'
+        , osname: 'WebOS'
+        , webos: t
+        , version: versionIdentifier || getFirstMatch(/w(?:eb)?osbrowser\/(\d+(\.\d+)?)/i)
+        };
+        /touchpad\//i.test(ua) && (result.touchpad = t)
+      }
+      else if (/bada/i.test(ua)) {
+        result = {
+          name: 'Bada'
+        , osname: 'Bada'
+        , bada: t
+        , version: getFirstMatch(/dolfin\/(\d+(\.\d+)?)/i)
+        };
+      }
+      else if (tizen) {
+        result = {
+          name: 'Tizen'
+        , osname: 'Tizen'
+        , tizen: t
+        , version: getFirstMatch(/(?:tizen\s?)?browser\/(\d+(\.\d+)?)/i) || versionIdentifier
+        };
+      }
+      else if (/qupzilla/i.test(ua)) {
+        result = {
+          name: 'QupZilla'
+          , qupzilla: t
+          , version: getFirstMatch(/(?:qupzilla)[\s\/](\d+(?:\.\d+)+)/i) || versionIdentifier
+        }
+      }
+      else if (/chromium/i.test(ua)) {
+        result = {
+          name: 'Chromium'
+          , chromium: t
+          , version: getFirstMatch(/(?:chromium)[\s\/](\d+(?:\.\d+)?)/i) || versionIdentifier
+        }
+      }
+      else if (/chrome|crios|crmo/i.test(ua)) {
+        result = {
+          name: 'Chrome'
+          , chrome: t
+          , version: getFirstMatch(/(?:chrome|crios|crmo)\/(\d+(\.\d+)?)/i)
+        }
+      }
+      else if (android) {
+        result = {
+          name: 'Android'
+          , version: versionIdentifier
+        }
+      }
+      else if (/safari|applewebkit/i.test(ua)) {
+        result = {
+          name: 'Safari'
+        , safari: t
+        }
+        if (versionIdentifier) {
+          result.version = versionIdentifier
+        }
+      }
+      else if (iosdevice) {
+        result = {
+          name : iosdevice == 'iphone' ? 'iPhone' : iosdevice == 'ipad' ? 'iPad' : 'iPod'
+        }
+        // WTF: version is not part of user agent in web apps
+        if (versionIdentifier) {
+          result.version = versionIdentifier
+        }
+      }
+      else if(/googlebot/i.test(ua)) {
+        result = {
+          name: 'Googlebot'
+        , googlebot: t
+        , version: getFirstMatch(/googlebot\/(\d+(\.\d+))/i) || versionIdentifier
+        }
+      }
+      else {
+        result = {
+          name: getFirstMatch(/^(.*)\/(.*) /),
+          version: getSecondMatch(/^(.*)\/(.*) /)
+       };
+     }
+
+      // set webkit or gecko flag for browsers based on these engines
+      if (!result.msedge && /(apple)?webkit/i.test(ua)) {
+        if (/(apple)?webkit\/537\.36/i.test(ua)) {
+          result.name = result.name || "Blink"
+          result.blink = t
+        } else {
+          result.name = result.name || "Webkit"
+          result.webkit = t
+        }
+        if (!result.version && versionIdentifier) {
+          result.version = versionIdentifier
+        }
+      } else if (!result.opera && /gecko\//i.test(ua)) {
+        result.name = result.name || "Gecko"
+        result.gecko = t
+        result.version = result.version || getFirstMatch(/gecko\/(\d+(\.\d+)?)/i)
+      }
+
+      // set OS flags for platforms that have multiple browsers
+      if (!result.windowsphone && (android || result.silk)) {
+        result.android = t
+        result.osname = 'Android'
+      } else if (!result.windowsphone && iosdevice) {
+        result[iosdevice] = t
+        result.ios = t
+        result.osname = 'iOS'
+      } else if (mac) {
+        result.mac = t
+        result.osname = 'macOS'
+      } else if (xbox) {
+        result.xbox = t
+        result.osname = 'Xbox'
+      } else if (windows) {
+        result.windows = t
+        result.osname = 'Windows'
+      } else if (linux) {
+        result.linux = t
+        result.osname = 'Linux'
+      }
+
+      function getWindowsVersion (s) {
+        switch (s) {
+          case 'NT': return 'NT'
+          case 'XP': return 'XP'
+          case 'NT 5.0': return '2000'
+          case 'NT 5.1': return 'XP'
+          case 'NT 5.2': return '2003'
+          case 'NT 6.0': return 'Vista'
+          case 'NT 6.1': return '7'
+          case 'NT 6.2': return '8'
+          case 'NT 6.3': return '8.1'
+          case 'NT 10.0': return '10'
+          default: return undefined
+        }
+      }
+
+      // OS version extraction
+      var osVersion = '';
+      if (result.windows) {
+        osVersion = getWindowsVersion(getFirstMatch(/Windows ((NT|XP)( \d\d?.\d)?)/i))
+      } else if (result.windowsphone) {
+        osVersion = getFirstMatch(/windows phone (?:os)?\s?(\d+(\.\d+)*)/i);
+      } else if (result.mac) {
+        osVersion = getFirstMatch(/Mac OS X (\d+([_\.\s]\d+)*)/i);
+        osVersion = osVersion.replace(/[_\s]/g, '.');
+      } else if (iosdevice) {
+        osVersion = getFirstMatch(/os (\d+([_\s]\d+)*) like mac os x/i);
+        osVersion = osVersion.replace(/[_\s]/g, '.');
+      } else if (android) {
+        osVersion = getFirstMatch(/android[ \/-](\d+(\.\d+)*)/i);
+      } else if (result.webos) {
+        osVersion = getFirstMatch(/(?:web|hpw)os\/(\d+(\.\d+)*)/i);
+      } else if (result.blackberry) {
+        osVersion = getFirstMatch(/rim\stablet\sos\s(\d+(\.\d+)*)/i);
+      } else if (result.bada) {
+        osVersion = getFirstMatch(/bada\/(\d+(\.\d+)*)/i);
+      } else if (result.tizen) {
+        osVersion = getFirstMatch(/tizen[\/\s](\d+(\.\d+)*)/i);
+      }
+      if (osVersion) {
+        result.osversion = osVersion;
+      }
+
+      // device type extraction
+      var osMajorVersion = !result.windows && osVersion.split('.')[0];
+      if (
+           tablet
+        || nexusTablet
+        || iosdevice == 'ipad'
+        || (android && (osMajorVersion == 3 || (osMajorVersion >= 4 && !mobile)))
+        || result.silk
+      ) {
+        result.tablet = t
+      } else if (
+           mobile
+        || iosdevice == 'iphone'
+        || iosdevice == 'ipod'
+        || android
+        || nexusMobile
+        || result.blackberry
+        || result.webos
+        || result.bada
+      ) {
+        result.mobile = t
+      }
+
+      // Graded Browser Support
+      // http://developer.yahoo.com/yui/articles/gbs
+      if (result.msedge ||
+          (result.msie && result.version >= 10) ||
+          (result.yandexbrowser && result.version >= 15) ||
+          (result.vivaldi && result.version >= 1.0) ||
+          (result.chrome && result.version >= 20) ||
+          (result.samsungBrowser && result.version >= 4) ||
+          (result.firefox && result.version >= 20.0) ||
+          (result.safari && result.version >= 6) ||
+          (result.opera && result.version >= 10.0) ||
+          (result.ios && result.osversion && result.osversion.split(".")[0] >= 6) ||
+          (result.blackberry && result.version >= 10.1)
+          || (result.chromium && result.version >= 20)
+          ) {
+        result.a = t;
+      }
+      else if ((result.msie && result.version < 10) ||
+          (result.chrome && result.version < 20) ||
+          (result.firefox && result.version < 20.0) ||
+          (result.safari && result.version < 6) ||
+          (result.opera && result.version < 10.0) ||
+          (result.ios && result.osversion && result.osversion.split(".")[0] < 6)
+          || (result.chromium && result.version < 20)
+          ) {
+        result.c = t
+      } else result.x = t
+
+      return result
+    }
+
+    var bowser = detect(typeof navigator !== 'undefined' ? navigator.userAgent || '' : '')
+
+    bowser.test = function (browserList) {
+      for (var i = 0; i < browserList.length; ++i) {
+        var browserItem = browserList[i];
+        if (typeof browserItem=== 'string') {
+          if (browserItem in bowser) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+
+    /**
+     * Get version precisions count
+     *
+     * @example
+     *   getVersionPrecision("1.10.3") // 3
+     *
+     * @param  {string} version
+     * @return {number}
+     */
+    function getVersionPrecision(version) {
+      return version.split(".").length;
+    }
+
+    /**
+     * Array::map polyfill
+     *
+     * @param  {Array} arr
+     * @param  {Function} iterator
+     * @return {Array}
+     */
+    function map(arr, iterator) {
+      var result = [], i;
+      if (Array.prototype.map) {
+        return Array.prototype.map.call(arr, iterator);
+      }
+      for (i = 0; i < arr.length; i++) {
+        result.push(iterator(arr[i]));
+      }
+      return result;
+    }
+
+    /**
+     * Calculate browser version weight
+     *
+     * @example
+     *   compareVersions(['1.10.2.1',  '1.8.2.1.90'])    // 1
+     *   compareVersions(['1.010.2.1', '1.09.2.1.90']);  // 1
+     *   compareVersions(['1.10.2.1',  '1.10.2.1']);     // 0
+     *   compareVersions(['1.10.2.1',  '1.0800.2']);     // -1
+     *
+     * @param  {Array<String>} versions versions to compare
+     * @return {Number} comparison result
+     */
+    function compareVersions(versions) {
+      // 1) get common precision for both versions, for example for "10.0" and "9" it should be 2
+      var precision = Math.max(getVersionPrecision(versions[0]), getVersionPrecision(versions[1]));
+      var chunks = map(versions, function (version) {
+        var delta = precision - getVersionPrecision(version);
+
+        // 2) "9" -> "9.0" (for precision = 2)
+        version = version + new Array(delta + 1).join(".0");
+
+        // 3) "9.0" -> ["000000000"", "000000009"]
+        return map(version.split("."), function (chunk) {
+          return new Array(20 - chunk.length).join("0") + chunk;
+        }).reverse();
+      });
+
+      // iterate in reverse order by reversed chunks array
+      while (--precision >= 0) {
+        // 4) compare: "000000009" > "000000010" = false (but "9" > "10" = true)
+        if (chunks[0][precision] > chunks[1][precision]) {
+          return 1;
+        }
+        else if (chunks[0][precision] === chunks[1][precision]) {
+          if (precision === 0) {
+            // all version chunks are same
+            return 0;
+          }
+        }
+        else {
+          return -1;
+        }
+      }
+    }
+
+    /**
+     * Check if browser is unsupported
+     *
+     * @example
+     *   bowser.isUnsupportedBrowser({
+     *     msie: "10",
+     *     firefox: "23",
+     *     chrome: "29",
+     *     safari: "5.1",
+     *     opera: "16",
+     *     phantom: "534"
+     *   });
+     *
+     * @param  {Object}  minVersions map of minimal version to browser
+     * @param  {Boolean} [strictMode = false] flag to return false if browser wasn't found in map
+     * @param  {String}  [ua] user agent string
+     * @return {Boolean}
+     */
+    function isUnsupportedBrowser(minVersions, strictMode, ua) {
+      var _bowser = bowser;
+
+      // make strictMode param optional with ua param usage
+      if (typeof strictMode === 'string') {
+        ua = strictMode;
+        strictMode = void(0);
+      }
+
+      if (strictMode === void(0)) {
+        strictMode = false;
+      }
+      if (ua) {
+        _bowser = detect(ua);
+      }
+
+      var version = "" + _bowser.version;
+      for (var browser in minVersions) {
+        if (minVersions.hasOwnProperty(browser)) {
+          if (_bowser[browser]) {
+            if (typeof minVersions[browser] !== 'string') {
+              throw new Error('Browser version in the minVersion map should be a string: ' + browser + ': ' + String(minVersions));
+            }
+
+            // browser version and min supported version.
+            return compareVersions([version, minVersions[browser]]) < 0;
+          }
+        }
+      }
+
+      return strictMode; // not found
+    }
+
+    /**
+     * Check if browser is supported
+     *
+     * @param  {Object} minVersions map of minimal version to browser
+     * @param  {Boolean} [strictMode = false] flag to return false if browser wasn't found in map
+     * @param  {String}  [ua] user agent string
+     * @return {Boolean}
+     */
+    function check(minVersions, strictMode, ua) {
+      return !isUnsupportedBrowser(minVersions, strictMode, ua);
+    }
+
+    bowser.isUnsupportedBrowser = isUnsupportedBrowser;
+    bowser.compareVersions = compareVersions;
+    bowser.check = check;
+
+    /*
+     * Set our detect method to the main bowser object so we can
+     * reuse it to test other user agents.
+     * This is needed to implement future tests.
+     */
+    bowser._detect = detect;
+
+    /*
+     * Set our detect public method to the main bowser object
+     * This is needed to implement bowser in server side
+     */
+    bowser.detect = detect;
+    return bowser
+  }();
+
+
+  var userAgent = window.navigator.userAgent
+
+  var minSupportedVersionsDesktop = {
+    chrome: '55',
+    chromium: '55',
+    firefox: '52',
+    safari: '11',
+    msedge: '15',
+    opera: '42',
+  }
+
+  var minSupportedVersionsMobile = {
+    ios: '11.2',
+    chrome: '64',
+    android: '62',
+    msedge: '15',
+    opera: '42',
+    firefox: '57',
+  }
+
+  var isMobileDevice = bowser.mobile || bowser.tablet
+  var isDesktop = isMobileDevice === undefined
+
+  var isBrowserSupported = (
+    (isDesktop && bowser.check(minSupportedVersionsDesktop, true, userAgent)) ||
+    (isMobileDevice && bowser.check(minSupportedVersionsMobile, true, userAgent))
+  )
+
+  if (!isBrowserSupported) {
+    alert('Your browser version is not supported. This app might not work.')
+  }
+})()

--- a/server/index.js
+++ b/server/index.js
@@ -29,6 +29,7 @@ app.get('/', (req, res) => {
       <head>
         <title>CardanoLite Wallet</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <script src="js/browserCompatibilityCheck.js" defer></script>
         <script src="js/frontend.bundle.js" defer></script>
         <link rel="stylesheet" type="text/css" href="css/styles.css">
         <link rel="icon" type="image/ico" href="assets/favicon.ico">


### PR DESCRIPTION
the script browserCompatibilityCheck checks the version/type of the browser and if the version is too low or the type is not supported (i.e. not in the list of minimum supported versions), it shows an alert. Tested on IE11. I had to "hard-wire" the bowser library into the script, because IE apparently does not like the code bundled by webpack without babel, but feel free to come suggest a different approach.