### PR TITLE
Use prettier-eslint instead of prettier & eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   "homepage": "https://github.com/vacuumlabs/cardano#readme",
   "lint-staged": {
     "{frontend,wallet,server,test}/**/*.{js,jsx,json,css}": [
-      "prettier --single-quote --write",
-      "eslint --fix",
+      "prettier-eslint --write",
       "git add"
     ]
   },


### PR DESCRIPTION
This may be a bug , but prettier-eslint does different formatting than running prettier first and the eslint.

Since at least VS Code (don't know about other editors) uses prettier-eslint, this is more in tune with format-on-save option.