### PR TITLE
Simplify transaction validation behavior

### DIFF
--- a/frontend/actions.js
+++ b/frontend/actions.js
@@ -111,12 +111,10 @@ export default ({setState, getState}) => {
 
     if (isNaN(amount) || strAmount.toLowerCase().includes('e')) {
       validationError = {code: 'SendAmountIsNan'}
-    }
-    if (strAmount.split('.').length === 2 && strAmount.split('.')[1].length > 6) {
-      validationError = {code: 'SendAmountPrecisionLimit'}
-    }
-    if (amount <= 0) {
+    } else if (amount <= 0) {
       validationError = {code: 'SendAmountIsNotPositive'}
+    } else if (strAmount.split('.').length === 2 && strAmount.split('.')[1].length > 6) {
+      validationError = {code: 'SendAmountPrecisionLimit'}
     }
 
     setState({sendAmount: Object.assign({}, state.sendAmount, {validationError})})

--- a/frontend/components.js
+++ b/frontend/components.js
@@ -340,7 +340,9 @@ const TransactionHistory = connect('transactionHistory')(({transactionHistory}) 
 const ConfirmTransactionDialog = connect(
   (state) => ({
     sendAddress: state.sendAddress.fieldValue,
-    totalAmount: (state.sendAmountForTransactionFee + state.transactionFee / 1000000).toFixed(6),
+    totalAmount: (parseFloat(state.sendAmount.fieldValue) + state.transactionFee / 1000000).toFixed(
+      6
+    ),
   }),
   actions
 )(({sendAddress, totalAmount, submitTransaction, cancelTransaction}) =>
@@ -490,9 +492,7 @@ const SendAda = connect(
     balance: parseFloat(state.balance) / 1000000,
     showConfirmTransactionDialog: state.showConfirmTransactionDialog,
     feeRecalculating: state.calculatingFee,
-    totalAmount: (
-      (state.sendAmountForTransactionFee + state.transactionFee) / 1000000
-    ).toFixed(6),
+    totalAmount: ((state.sendAmountForTransactionFee + state.transactionFee) / 1000000).toFixed(6),
   }),
   actions
 )(SendAdaClass)

--- a/frontend/components.js
+++ b/frontend/components.js
@@ -340,9 +340,7 @@ const TransactionHistory = connect('transactionHistory')(({transactionHistory}) 
 const ConfirmTransactionDialog = connect(
   (state) => ({
     sendAddress: state.sendAddress.fieldValue,
-    totalAmount: (parseFloat(state.sendAmount.fieldValue) + state.transactionFee / 1000000).toFixed(
-      6
-    ),
+    totalAmount: (state.sendAmountForTransactionFee + state.transactionFee / 1000000).toFixed(6),
   }),
   actions
 )(({sendAddress, totalAmount, submitTransaction, cancelTransaction}) =>
@@ -381,13 +379,7 @@ class SendAdaClass extends Component {
     const enableSubmit =
       sendAmount && !sendAmountValidationError && sendAddress && !sendAddressValidationError
 
-    const displayTransactionFee =
-      sendAmount !== '' &&
-      !feeRecalculating &&
-      transactionFee > 0 &&
-      !sendAddressValidationError &&
-      (!sendAmountValidationError ||
-        sendAmountValidationError.code === 'SendAmountInsufficientFundsForFee')
+    const displayTransactionFee = sendAmount !== '' && transactionFee > 0
 
     return h(
       'div',
@@ -449,7 +441,6 @@ class SendAdaClass extends Component {
           h('input', {
             type: 'number',
             min: 0,
-            max: balance,
             step: 0.000001,
             id: 'send-amount',
             name: 'send-amount',
@@ -462,7 +453,7 @@ class SendAdaClass extends Component {
           displayTransactionFee &&
             h(
               'span',
-              {style: `color: ${sendAmountValidationError ? 'red' : 'green'}`},
+              {style: `color: ${feeRecalculating || !enableSubmit ? 'red' : 'green'}`},
               `= ${totalAmount} ADA`
             )
         ),
@@ -500,8 +491,7 @@ const SendAda = connect(
     showConfirmTransactionDialog: state.showConfirmTransactionDialog,
     feeRecalculating: state.calculatingFee,
     totalAmount: (
-      parseFloat(state.sendAmount.fieldValue || 0) +
-      state.transactionFee / 1000000
+      (state.sendAmountForTransactionFee + state.transactionFee) / 1000000
     ).toFixed(6),
   }),
   actions

--- a/frontend/translations.js
+++ b/frontend/translations.js
@@ -1,8 +1,8 @@
 module.exports = {
   SendAddressInvalidAddress: () => 'Invalid address',
   SendAmountIsNan: () => 'Invalid format: Amount has to be a number',
-  SenAmountIsNotPositive: () => 'Invalid format: Amount has to be a positive number',
-  SendAmountInsufficientFunds: ({balance}) => `Insufficient funds. Your balance is ${balance} ADA.`,
-  SendAmountInsufficientFundsForFee: ({balance, transactionFee}) => `Insufficient funds to cover the transaction fee. 
-    Cannot send more than ${balance - transactionFee} ADA.`,
+  SendAmountIsNotPositive: () => 'Invalid format: Amount has to be a positive number',
+  SendAmountInsufficientFunds: ({balance}) =>
+    `Insufficient funds for the transaction. Your balance is ${balance / 1000000} ADA.`,
+  SendAmountPrecisionLimit: () => 'Invalid format: Maximum allowed precision is 0.000001',
 }

--- a/frontend/walletApp.js
+++ b/frontend/walletApp.js
@@ -39,6 +39,7 @@ const initialState = {
   sendAddress: {fieldValue: ''},
   sendAmount: {fieldValue: 0},
   transactionFee: 0,
+  sendAmountForTransactionFee: 0,
   router: {
     pathname: window.location.pathname,
     hash: window.location.hash,

--- a/wallet/cardano-wallet.js
+++ b/wallet/cardano-wallet.js
@@ -193,9 +193,10 @@ const CardanoWallet = (secretOrMnemonic, CARDANOLITE_CONFIG) => {
     let result
 
     if (usedAddressesAndSecrets.length < usedAddressesLimit) {
-      const highestUsedChildIndex = usedAddressesAndSecrets.reduce((acc, item) => {
-        return Math.max(item.childIndex, acc)
-      }, 0x80000000)
+      const highestUsedChildIndex = Math.max(
+        0x8000000,
+        ...usedAddressesAndSecrets.map((item) => item.childIndex)
+      )
 
       result = (await getAddressAndSecret(highestUsedChildIndex + 1 + offset)).address
     } else {

--- a/wallet/cardano-wallet.js
+++ b/wallet/cardano-wallet.js
@@ -155,7 +155,7 @@ const CardanoWallet = (secretOrMnemonic, CARDANOLITE_CONFIG) => {
     }, 0)
 
     const out1coins = coins
-    const out2coinsUpperBound = txInputsCoinsSum - coins
+    const out2coinsUpperBound = Math.max(0, txInputsCoinsSum - coins)
 
     // the +1 is there because in the actual transaction
     // the txInputs are encoded as indefinite length array
@@ -193,10 +193,9 @@ const CardanoWallet = (secretOrMnemonic, CARDANOLITE_CONFIG) => {
     let result
 
     if (usedAddressesAndSecrets.length < usedAddressesLimit) {
-      const highestUsedChildIndex =
-        usedAddressesAndSecrets.reduce((acc, item) => {
-          return Math.max(item.childIndex, acc)
-        }, 0x80000000)
+      const highestUsedChildIndex = usedAddressesAndSecrets.reduce((acc, item) => {
+        return Math.max(item.childIndex, acc)
+      }, 0x80000000)
 
       result = (await getAddressAndSecret(highestUsedChildIndex + 1 + offset)).address
     } else {


### PR DESCRIPTION
II simplified the validation behavior so that the transaction fee does not disapper when computing it but it turns red and stays like that until the transaction fee computation passes.

I tried also to avoid the disappearing of the validation message when the address changes but I could not find a solution that I would be satisfied with. Feel free to suggest any.