### PR TITLE
Collapse mobile menu on click on nav elements

### DIFF
--- a/frontend/components.js
+++ b/frontend/components.js
@@ -575,20 +575,20 @@ const LoginStatus = connect(
       'div',
       {class: 'status-button-wrapper'},
       h(
-        'button',
-        {onClick: reloadWalletInfo},
+        'label',
+        {class: 'inline', for: 'navcollapse'},
         h(
-          'label',
-          {class: 'inline', for: 'navcollapse'},
+          'div',
+          {class: 'button', onClick: reloadWalletInfo},
           h(RefreshIcon),
           h('div', {class: 'status-icon-button-content'}, 'Refresh')
+        ),
+        h(
+          'div',
+          {class: 'button', onClick: logout},
+          h(ExitIcon),
+          h('div', {class: 'status-icon-button-content'}, 'Logout')
         )
-      ),
-      h(
-        'button',
-        {onClick: logout},
-        h(ExitIcon),
-        h('div', {class: 'status-icon-button-content'}, 'Logout')
       )
     )
   )
@@ -671,7 +671,7 @@ const NavbarAuth = connect((state) => ({
                 class: currentTab === 'send' && 'active',
                 onClick: () => pushState({}, 'send', 'send'),
               },
-              h('label', {class: 'inline', for: 'navcollapse'}, 'Send')
+              'Send'
             )
           ),
           h(
@@ -683,7 +683,7 @@ const NavbarAuth = connect((state) => ({
                 class: currentTab === 'receive' && 'active',
                 onClick: () => pushState({}, 'receive', 'receive'),
               },
-              h('label', {class: 'inline', for: 'navcollapse'}, 'Receive')
+              'Receive'
             )
           )
         ),

--- a/frontend/components.js
+++ b/frontend/components.js
@@ -608,7 +608,11 @@ const NavbarUnauth = () =>
         h('span', undefined, 'CardanoLite Wallet'),
         h('sup', undefined, '⍺')
       ),
-      h('label', {class: 'navcollapse-label', for: 'navcollapse'}, 'Menu'),
+      h(
+        'label',
+        {class: 'navcollapse-label', for: 'navcollapse'},
+        h('a', {class: 'menu-btn'}, 'Menu')
+      ),
       h('input', {id: 'navcollapse', type: 'checkbox'}),
       h(
         'nav',
@@ -642,7 +646,11 @@ const NavbarAuth = connect((state) => ({
         h('span', undefined, 'CardanoLite Wallet'),
         h('sup', undefined, '⍺')
       ),
-      h('label', {class: 'navcollapse-label', for: 'navcollapse'}, 'Menu'),
+      h(
+        'label',
+        {class: 'navcollapse-label', for: 'navcollapse'},
+        h('a', {class: 'menu-btn'}, 'Menu')
+      ),
       h('input', {id: 'navcollapse', type: 'checkbox'}),
       h(
         'nav',

--- a/frontend/components.js
+++ b/frontend/components.js
@@ -644,31 +644,35 @@ const NavbarAuth = connect((state) => ({
         'nav',
         undefined,
         h(
-          'div',
-          undefined,
+          'label',
+          {class: 'navcollapse-label', for: 'navcollapse'},
           h(
-            'a',
-            {
-              class: currentTab === 'dashboard' && 'active',
-              onClick: () => pushState({}, 'dashboard', 'dashboard'),
-            },
-            'Dashboard'
-          ),
-          h(
-            'a',
-            {
-              class: currentTab === 'send' && 'active',
-              onClick: () => pushState({}, 'send', 'send'),
-            },
-            'Send'
-          ),
-          h(
-            'a',
-            {
-              class: currentTab === 'receive' && 'active',
-              onClick: () => pushState({}, 'receive', 'receive'),
-            },
-            'Receive'
+            'div',
+            undefined,
+            h(
+              'a',
+              {
+                class: currentTab === 'dashboard' && 'active',
+                onClick: () => pushState({}, 'dashboard', 'dashboard'),
+              },
+              'Dashboard'
+            ),
+            h(
+              'a',
+              {
+                class: currentTab === 'send' && 'active',
+                onClick: () => pushState({}, 'send', 'send'),
+              },
+              'Send'
+            ),
+            h(
+              'a',
+              {
+                class: currentTab === 'receive' && 'active',
+                onClick: () => pushState({}, 'receive', 'receive'),
+              },
+              'Receive'
+            )
           )
         ),
         h(LoginStatus)

--- a/frontend/components.js
+++ b/frontend/components.js
@@ -577,8 +577,12 @@ const LoginStatus = connect(
       h(
         'button',
         {onClick: reloadWalletInfo},
-        h(RefreshIcon),
-        h('div', {class: 'status-icon-button-content'}, 'Refresh')
+        h(
+          'label',
+          {class: 'inline', for: 'navcollapse'},
+          h(RefreshIcon),
+          h('div', {class: 'status-icon-button-content'}, 'Refresh')
+        )
       ),
       h(
         'button',
@@ -644,35 +648,31 @@ const NavbarAuth = connect((state) => ({
         'nav',
         undefined,
         h(
-          'label',
-          {class: 'navcollapse-label', for: 'navcollapse'},
+          'div',
+          undefined,
           h(
-            'div',
-            undefined,
-            h(
-              'a',
-              {
-                class: currentTab === 'dashboard' && 'active',
-                onClick: () => pushState({}, 'dashboard', 'dashboard'),
-              },
-              'Dashboard'
-            ),
-            h(
-              'a',
-              {
-                class: currentTab === 'send' && 'active',
-                onClick: () => pushState({}, 'send', 'send'),
-              },
-              'Send'
-            ),
-            h(
-              'a',
-              {
-                class: currentTab === 'receive' && 'active',
-                onClick: () => pushState({}, 'receive', 'receive'),
-              },
-              'Receive'
-            )
+            'a',
+            {
+              class: currentTab === 'dashboard' && 'active',
+              onClick: () => pushState({}, 'dashboard', 'dashboard'),
+            },
+            h('label', {class: 'inline', for: 'navcollapse'}, 'Dashboard')
+          ),
+          h(
+            'a',
+            {
+              class: currentTab === 'send' && 'active',
+              onClick: () => pushState({}, 'send', 'send'),
+            },
+            h('label', {class: 'inline', for: 'navcollapse'}, 'Send')
+          ),
+          h(
+            'a',
+            {
+              class: currentTab === 'receive' && 'active',
+              onClick: () => pushState({}, 'receive', 'receive'),
+            },
+            h('label', {class: 'inline', for: 'navcollapse'}, 'Receive')
           )
         ),
         h(LoginStatus)

--- a/frontend/components.js
+++ b/frontend/components.js
@@ -651,28 +651,40 @@ const NavbarAuth = connect((state) => ({
           'div',
           undefined,
           h(
-            'a',
-            {
-              class: currentTab === 'dashboard' && 'active',
-              onClick: () => pushState({}, 'dashboard', 'dashboard'),
-            },
-            h('label', {class: 'inline', for: 'navcollapse'}, 'Dashboard')
+            'label',
+            {class: 'inline', for: 'navcollapse'},
+            h(
+              'a',
+              {
+                class: currentTab === 'dashboard' && 'active',
+                onClick: () => pushState({}, 'dashboard', 'dashboard'),
+              },
+              'Dashboard'
+            )
           ),
           h(
-            'a',
-            {
-              class: currentTab === 'send' && 'active',
-              onClick: () => pushState({}, 'send', 'send'),
-            },
-            h('label', {class: 'inline', for: 'navcollapse'}, 'Send')
+            'label',
+            {class: 'inline', for: 'navcollapse'},
+            h(
+              'a',
+              {
+                class: currentTab === 'send' && 'active',
+                onClick: () => pushState({}, 'send', 'send'),
+              },
+              h('label', {class: 'inline', for: 'navcollapse'}, 'Send')
+            )
           ),
           h(
-            'a',
-            {
-              class: currentTab === 'receive' && 'active',
-              onClick: () => pushState({}, 'receive', 'receive'),
-            },
-            h('label', {class: 'inline', for: 'navcollapse'}, 'Receive')
+            'label',
+            {class: 'inline', for: 'navcollapse'},
+            h(
+              'a',
+              {
+                class: currentTab === 'receive' && 'active',
+                onClick: () => pushState({}, 'receive', 'receive'),
+              },
+              h('label', {class: 'inline', for: 'navcollapse'}, 'Receive')
+            )
           )
         ),
         h(LoginStatus)

--- a/public_wallet_app/css/styles.css
+++ b/public_wallet_app/css/styles.css
@@ -489,7 +489,7 @@ td {
 .status > div {
   margin: 0 0.6rem 0 0.6rem;
 }
-.status button {
+.status .button {
   background-color: var(--navbar);
   color: var(--text-color);
   border: 0;
@@ -499,8 +499,11 @@ td {
   padding: 2px;
   height: 2.5rem;
   border-radius: 0;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
 }
-.status button:hover {
+.status .button:hover {
   color: var(--brand);
 }
 .status-text {

--- a/public_wallet_app/css/styles.css
+++ b/public_wallet_app/css/styles.css
@@ -419,6 +419,16 @@ td {
   margin: 0 0.8rem;
 }
 /* NAVIGATION */
+.menu-btn{
+  color: var(--navbar-text);
+  text-decoration: none;
+  margin-left: 1rem;
+  transition: color var(--transition);
+  cursor: pointer;
+}
+.menu-btn:hover {
+  color: black;
+}
 .navbar {
   background-color: var(--navbar);
   border-bottom: 1px solid var(--border);

--- a/public_wallet_app/css/styles.css
+++ b/public_wallet_app/css/styles.css
@@ -526,6 +526,9 @@ td {
   width: 0.9rem;
   height: 0.9rem;
 }
+.inline {
+  display: inline;
+}
 @media screen and (max-width: 840px) {
   body {
     padding-top: 3.5rem;


### PR DESCRIPTION
- does not collapse on click on status part
- does not solve the problem of rendering page wider than narrow screens at receive (transparent tooltips widen the page over screen edge)  
closes #71 